### PR TITLE
Fix for redundant imports.

### DIFF
--- a/change/@boll-cli-2020-09-01-12-21-53-redundant-import-fix.json
+++ b/change/@boll-cli-2020-09-01-12-21-53-redundant-import-fix.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix for redundant imports.",
+  "packageName": "@boll/cli",
+  "email": "jdh@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-09-01T19:21:53.326Z"
+}

--- a/packages/cli/fixtures/clean/src/uses-imports-from-other-files.ts
+++ b/packages/cli/fixtures/clean/src/uses-imports-from-other-files.ts
@@ -1,0 +1,3 @@
+import { bar } from "./just-fine";
+import { blah } from "fakePackage/lib/blah";
+import { foo } from "@scope/everything/ok/here";

--- a/packages/cli/src/rules/redundant-imports-detector.ts
+++ b/packages/cli/src/rules/redundant-imports-detector.ts
@@ -15,15 +15,14 @@ import { asBollLineNumber } from "../lib/boll-line-number";
  */
 const ruleName = "RedundantImportsDetector";
 export class RedundantImportsDetector implements PackageRule {
-  _importLocationSet: Set<string> = new Set();
-
   check(fileContext: FileContext): Result[] {
     return this.checkImportPaths(fileContext.filename, this.getImportPaths(fileContext.source));
   }
 
   checkImportPaths(fileName: BollFile, importPaths: string[]): Result[] {
+    const importLocations: Set<string> = new Set();
     const results = importPaths
-      .filter((i) => (this._importLocationSet.has(i) ? true : (this._importLocationSet.add(i), false)))
+      .filter((i) => (importLocations.has(i) ? true : (importLocations.add(i), false)))
       .map((i) => {
         return new Failure(
           ruleName,


### PR DESCRIPTION
In OOUI this was failing on lots of files because it keeps the set of imported files for the whole run of the project. Changing to to be a per-file check.