### PR TITLE
Implement boll disable next line rule support

### DIFF
--- a/change/@boll-core-2020-11-30-16-47-45-vipati-boll-disable-next-line-rule.json
+++ b/change/@boll-core-2020-11-30-16-47-45-vipati-boll-disable-next-line-rule.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Adding boll disable next line rule",
+  "packageName": "@boll/core",
+  "email": "vipati@microsoft.com",
+  "dependentChangeType": "patch",
+  "date": "2020-12-01T00:47:45.662Z"
+}

--- a/packages/core/fixtures/standalone-source-files/multiple-disable-next-line.ts
+++ b/packages/core/fixtures/standalone-source-files/multiple-disable-next-line.ts
@@ -1,0 +1,6 @@
+/* boll-disable-next-line MadeUpCheckName, AlsoMadeUpName */
+const foo = "bar";
+const val = 1;
+/* boll-disable-next-line MadeUpCheckName */
+export const blah = () => console.log("hello, world");
+

--- a/packages/core/fixtures/standalone-source-files/simple-disable-next-line.ts
+++ b/packages/core/fixtures/standalone-source-files/simple-disable-next-line.ts
@@ -1,0 +1,4 @@
+const foo = "bar";
+const val = 1;
+/* boll-disable-next-line MadeUpCheckName */
+export const blah = () => console.log("hello, world");

--- a/packages/core/src/file-context.ts
+++ b/packages/core/src/file-context.ts
@@ -54,10 +54,10 @@ export class FileContext {
   }
 
   get ignoredChecksByLine(): Map<number, string[]> {
-    const sourceFile =  ts.createSourceFile(this.filename, this.content, ts.ScriptTarget.ES5, true);
+    const sourceFile = ts.createSourceFile(this.filename, this.content, ts.ScriptTarget.ES5, true);
 
     if (!sourceFile) return this._ignoredChecksByLine;
-    
+
     sourceFile.forEachChild(n => {
       const lineNumber = sourceFile.getLineAndCharacterOfPosition(n.pos).line;
       const trimmedNodeText = n.getFullText().trim();
@@ -72,8 +72,7 @@ export class FileContext {
             .forEach(rule => ignoredChecks.push(rule));
         }
       });
-      if (ignoredChecks.length > 0)
-        this._ignoredChecksByLine.set(lineNumber, ignoredChecks);
+      if (ignoredChecks.length > 0) this._ignoredChecksByLine.set(lineNumber, ignoredChecks);
     });
 
     return this._ignoredChecksByLine;

--- a/packages/core/src/tests/pragma.test.ts
+++ b/packages/core/src/tests/pragma.test.ts
@@ -18,3 +18,22 @@ test("should keep track of multiple disabled rules in a FileContext", async () =
     assert.deepStrictEqual(sut.ignoredChecks, ["MadeUpCheckName", "AlsoMadeUpName"]);
   });
 });
+
+test("should keep track of a disabled next line rules in a FileContext", async () => {
+  await inFixtureDir("standalone-source-files", __dirname, async cwd => {
+    const sut = await getSourceFile(cwd, "simple-disable-next-line.ts", new Package({}, {}));
+    const expectedResult = new Map();
+    expectedResult.set(1,['MadeUpCheckName']);
+    assert.deepStrictEqual(sut.ignoredChecksByLine, expectedResult);
+  });
+});
+
+test("should keep track of a disabled next line rules in a FileContext", async () => {
+  await inFixtureDir("standalone-source-files", __dirname, async cwd => {
+    const sut = await getSourceFile(cwd, "multiple-disable-next-line.ts", new Package({}, {}));
+    const expectedResult = new Map();
+    expectedResult.set(0,['MadeUpCheckName', 'AlsoMadeUpName']);
+    expectedResult.set(2,['MadeUpCheckName']);
+    assert.deepStrictEqual(sut.ignoredChecksByLine, expectedResult);
+  });
+});

--- a/packages/core/src/tests/pragma.test.ts
+++ b/packages/core/src/tests/pragma.test.ts
@@ -23,7 +23,7 @@ test("should keep track of a disabled next line rules in a FileContext", async (
   await inFixtureDir("standalone-source-files", __dirname, async cwd => {
     const sut = await getSourceFile(cwd, "simple-disable-next-line.ts", new Package({}, {}));
     const expectedResult = new Map();
-    expectedResult.set(1,['MadeUpCheckName']);
+    expectedResult.set(1, ["MadeUpCheckName"]);
     assert.deepStrictEqual(sut.ignoredChecksByLine, expectedResult);
   });
 });
@@ -32,8 +32,8 @@ test("should keep track of a disabled next line rules in a FileContext", async (
   await inFixtureDir("standalone-source-files", __dirname, async cwd => {
     const sut = await getSourceFile(cwd, "multiple-disable-next-line.ts", new Package({}, {}));
     const expectedResult = new Map();
-    expectedResult.set(0,['MadeUpCheckName', 'AlsoMadeUpName']);
-    expectedResult.set(2,['MadeUpCheckName']);
+    expectedResult.set(0, ["MadeUpCheckName", "AlsoMadeUpName"]);
+    expectedResult.set(2, ["MadeUpCheckName"]);
     assert.deepStrictEqual(sut.ignoredChecksByLine, expectedResult);
   });
 });


### PR DESCRIPTION
As per the issue `https://github.com/microsoft/boll/issues/41`, Implemented the boll disable next line rule support.

- Added `ignoredChecksByLine` method in FileContext and to return the map of lineNumber and rules to be disabled at the given line.
- Multiple rules that need to be disabled should be `,` separated.
- Added Test case for single and multiple rules disabling at the next line.