### PR TITLE
Fix node modules detector line numbers

### DIFF
--- a/packages/rules-typescript/src/node-modules-reference-detector.ts
+++ b/packages/rules-typescript/src/node-modules-reference-detector.ts
@@ -58,12 +58,12 @@ export class NodeModulesReferenceDetector implements PackageRule {
         .split(MULTI_LINE_COMMENT_REGEXP)
         .map(n => n && n.trim())
         .filter(n => n)
-        .join('\r\n');
+        .join("\r\n");
       const singleLineCommentsRemovedText = multiLineCommentsRemovedText
         .split(SINGLE_LINE_COMMENT_REGEXP)
         .map(n => n && n.trim())
         .filter(n => n)
-        .join('\r\n');
+        .join("\r\n");
       parsedSourceLines.push({ line: singleLineCommentsRemovedText, lineNumber: lineNumber });
     });
     return parsedSourceLines;

--- a/packages/rules-typescript/src/node-modules-reference-detector.ts
+++ b/packages/rules-typescript/src/node-modules-reference-detector.ts
@@ -49,20 +49,22 @@ export class NodeModulesReferenceDetector implements PackageRule {
 
   getParsedSourceLines(sourceFile: SourceFile): SourceLineAndLineNumber[] {
     const parsedSourceLines: SourceLineAndLineNumber[] = [];
+    let lineNumber = 1;
     sourceFile.forEachChild(n => {
-      const lineNumber = sourceFile.getLineAndCharacterOfPosition(n.pos).line;
+      const totalLines = n.getFullText().split(/\r?\n/).length;
+      lineNumber = lineNumber + totalLines - 1;
       const trimmedNodeText = n.getFullText().trim();
       const multiLineCommentsRemovedText = trimmedNodeText
         .split(MULTI_LINE_COMMENT_REGEXP)
         .map(n => n && n.trim())
         .filter(n => n)
-        .join("");
+        .join('\r\n');
       const singleLineCommentsRemovedText = multiLineCommentsRemovedText
         .split(SINGLE_LINE_COMMENT_REGEXP)
         .map(n => n && n.trim())
         .filter(n => n)
-        .join("");
-      parsedSourceLines.push({ line: singleLineCommentsRemovedText, lineNumber });
+        .join('\r\n');
+      parsedSourceLines.push({ line: singleLineCommentsRemovedText, lineNumber: lineNumber });
     });
     return parsedSourceLines;
   }

--- a/packages/rules-typescript/src/tests/node-modules-reference-detector.test.ts
+++ b/packages/rules-typescript/src/tests/node-modules-reference-detector.test.ts
@@ -1,7 +1,7 @@
 import * as assert from "assert";
 import baretest from "baretest";
 import { NodeModulesReferenceDetector } from "../node-modules-reference-detector";
-import { asBollDirectory, getSourceFile, Package, ResultStatus } from "@boll/core";
+import { asBollDirectory, getSourceFile, Package, ResultStatus, Failure } from "@boll/core";
 import { inFixtureDir } from "@boll/test-internal";
 
 export const test: any = baretest("Node modules reference detector");
@@ -23,8 +23,12 @@ test("Should fail if references to node_modules exist in source code", async () 
     const result = await sut.check(
       await getSourceFile(asBollDirectory("."), "node-modules-reference.ts", new Package({}, {}))
     );
+    const failure = result[0] as Failure;
+    const failure1 = result[1] as Failure;
     assert.strictEqual(2, result.length);
     assert.strictEqual(ResultStatus.failure, result[0].status);
     assert.strictEqual(ResultStatus.failure, result[1].status);
+    assert.strictEqual(1, failure.line);
+    assert.strictEqual(5, failure1.line);
   });
 });


### PR DESCRIPTION
1) Current line numbers generated by Node Modules Detector 
2) Fixed logic to remove the single line and multiline comment. Instead of directly joining the lines, joined it by `\r\n` so we do not lose any content. 
For example,
```
//SingleLine comment
/*
multiline comment
*/
const f = f.fileContext();
```
When we process this through node modules, we lose the code `const f = f.fileContext();` due to single line and multiline comment replacement logic.
3)Each node from SourceFile contains a single line. It will be prefixed by `\r\n` or single line comment or multiline comment or combination.
Some valid examples are,
```

const f = f.fileContext();
```
```
//SingleLine comment
/*
multiline comment
*/
const f = f.fileContext();
```
```
//SingleLine comment
const f = f.fileContext();
```
```
/*
multiline comment
*/
const f = f.fileContext();
```
