### PR TITLE
src detector line number fix

### DIFF
--- a/packages/rules-typescript/fixtures/src-detector/src-detector.ts
+++ b/packages/rules-typescript/fixtures/src-detector/src-detector.ts
@@ -1,0 +1,16 @@
+import * as FakeImport from "@foo/src/FakeImport";
+/*
+correct import
+*/
+import * as CorrectImport from "@foo/foo/CorrectImport";
+
+//SrcImport
+import * as SrcImport from "@foo/src/SrcImport";
+
+const dummyCode = "foo";
+const moreDummyCode = dummyCode.split("o");
+const dummyScriptPath = "../../node_modules/some-package/lib/some-script.js";
+const fakeObject = new FakeImport(dummyCode, moreDummyCode, dummyScriptPath);
+
+// This is a comment containing the word node_modules. This should not be flagged.
+fakeObject.doNothing();

--- a/packages/rules-typescript/src/src-detector.ts
+++ b/packages/rules-typescript/src/src-detector.ts
@@ -55,9 +55,6 @@ export class SrcDetector implements PackageRule {
       const totalLines = n.getFullText().split(/\r?\n/).length;
       lineNumber = lineNumber + totalLines - 1;
       if (isImportDeclaration(n)) {
-        console.log("==================================>>>>>>>>>>>>");
-        console.log("path : " + n.moduleSpecifier.getText());
-        console.log("lineNumber : " + lineNumber);
         importPaths.push({
           path: n.moduleSpecifier.getText(),
           lineNumber: lineNumber

--- a/packages/rules-typescript/src/src-detector.ts
+++ b/packages/rules-typescript/src/src-detector.ts
@@ -50,11 +50,17 @@ export class SrcDetector implements PackageRule {
 
   getImportPaths(sourceFile: SourceFile): ImportPathAndLineNumber[] {
     const importPaths: ImportPathAndLineNumber[] = [];
+    let lineNumber = 1;
     sourceFile.forEachChild(n => {
+      const totalLines = n.getFullText().split(/\r?\n/).length;
+      lineNumber = lineNumber + totalLines - 1;
       if (isImportDeclaration(n)) {
+        console.log('==================================>>>>>>>>>>>>');
+        console.log('path : ' + n.moduleSpecifier.getText());
+        console.log('lineNumber : ' + lineNumber);
         importPaths.push({
           path: n.moduleSpecifier.getText(),
-          lineNumber: sourceFile.getLineAndCharacterOfPosition(n.pos).line
+          lineNumber: lineNumber
         });
       }
     });

--- a/packages/rules-typescript/src/src-detector.ts
+++ b/packages/rules-typescript/src/src-detector.ts
@@ -55,9 +55,9 @@ export class SrcDetector implements PackageRule {
       const totalLines = n.getFullText().split(/\r?\n/).length;
       lineNumber = lineNumber + totalLines - 1;
       if (isImportDeclaration(n)) {
-        console.log('==================================>>>>>>>>>>>>');
-        console.log('path : ' + n.moduleSpecifier.getText());
-        console.log('lineNumber : ' + lineNumber);
+        console.log("==================================>>>>>>>>>>>>");
+        console.log("path : " + n.moduleSpecifier.getText());
+        console.log("lineNumber : " + lineNumber);
         importPaths.push({
           path: n.moduleSpecifier.getText(),
           lineNumber: lineNumber

--- a/packages/rules-typescript/src/tests/src-detector.test.ts
+++ b/packages/rules-typescript/src/tests/src-detector.test.ts
@@ -25,7 +25,7 @@ test("Should fail if `src` detected in imports", async () => {
   assert.strictEqual(ResultStatus.failure, result[0].status);
 });
 
-test("Should fail if references to node_modules exist in source code", async () => {
+test("Should fail if references to `src` detected in imports", async () => {
   inFixtureDir("src-detector", __dirname, async () => {
     const sut = new SrcDetector();
     const result = await sut.check(await getSourceFile(asBollDirectory("."), "src-detector.ts", new Package({}, {})));

--- a/packages/rules-typescript/src/tests/src-detector.test.ts
+++ b/packages/rules-typescript/src/tests/src-detector.test.ts
@@ -20,7 +20,7 @@ test("Should fail if `src` detected in imports", async () => {
     { path: "a/src/b", lineNumber: 0 },
     { path: "b/c/d/e/f", lineNumber: 1 }
   ];
-  const sut = new SrcDetector(); 
+  const sut = new SrcDetector();
   const result = sut.checkImportPaths(asBollFile("a"), importPaths);
   assert.strictEqual(ResultStatus.failure, result[0].status);
 });
@@ -28,9 +28,7 @@ test("Should fail if `src` detected in imports", async () => {
 test("Should fail if references to node_modules exist in source code", async () => {
   inFixtureDir("src-detector", __dirname, async () => {
     const sut = new SrcDetector();
-    const result = await sut.check(
-      await getSourceFile(asBollDirectory("."), "src-detector.ts", new Package({}, {}))
-    );
+    const result = await sut.check(await getSourceFile(asBollDirectory("."), "src-detector.ts", new Package({}, {})));
     const failure = result[0] as Failure;
     const failure1 = result[1] as Failure;
     assert.strictEqual(2, result.length);

--- a/packages/rules-typescript/src/tests/src-detector.test.ts
+++ b/packages/rules-typescript/src/tests/src-detector.test.ts
@@ -1,7 +1,8 @@
 import * as assert from "assert";
 import baretest from "baretest";
-import { asBollFile, ResultStatus } from "@boll/core";
+import { asBollDirectory, getSourceFile, asBollFile, Failure, Package, ResultStatus } from "@boll/core";
 import { SrcDetector } from "../src-detector";
+import { inFixtureDir } from "@boll/test-internal";
 export const test: any = baretest("Source detector");
 
 test("Should pass if no `src` detected in imports", async () => {
@@ -19,7 +20,23 @@ test("Should fail if `src` detected in imports", async () => {
     { path: "a/src/b", lineNumber: 0 },
     { path: "b/c/d/e/f", lineNumber: 1 }
   ];
-  const sut = new SrcDetector();
+  const sut = new SrcDetector(); 
   const result = sut.checkImportPaths(asBollFile("a"), importPaths);
   assert.strictEqual(ResultStatus.failure, result[0].status);
+});
+
+test("Should fail if references to node_modules exist in source code", async () => {
+  inFixtureDir("src-detector", __dirname, async () => {
+    const sut = new SrcDetector();
+    const result = await sut.check(
+      await getSourceFile(asBollDirectory("."), "src-detector.ts", new Package({}, {}))
+    );
+    const failure = result[0] as Failure;
+    const failure1 = result[1] as Failure;
+    assert.strictEqual(2, result.length);
+    assert.strictEqual(ResultStatus.failure, result[0].status);
+    assert.strictEqual(ResultStatus.failure, result[1].status);
+    assert.strictEqual(1, failure.line);
+    assert.strictEqual(8, failure1.line);
+  });
 });


### PR DESCRIPTION
- Fixed logic to correctly show the line number of the code where error/warning is present
- It will help with disable-next-line rule