### PR TITLE
Group results

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,14 +1,23 @@
 import * as fs from "fs";
 import { ConfigGenerator } from "./config-generator";
-import { Config, configFileName, ConfigRegistryInstance, Logger, ResultSet, RuleRegistryInstance, RuleResult, GroupedResult, Suite } from "@boll/core";
+import {
+  Config,
+  configFileName,
+  ConfigRegistryInstance,
+  Logger,
+  ResultSet,
+  RuleRegistryInstance,
+  RuleResult,
+  GroupedResult,
+  Suite
+} from "@boll/core";
 import { promisify } from "util";
 import { resolve } from "path";
 import { Formatter } from "./lib/formatter";
 import { DefaultFormatter } from "./lib/default-formatter";
 import { VsoFormatter } from "./lib/vso-formatter";
-import { ParsedCommand, parser } from './parser';
+import { ParsedCommand, parser } from "./parser";
 const fileExistsAsync = promisify(fs.exists);
-
 
 export enum Status {
   Ok,
@@ -26,10 +35,11 @@ export class Cli {
       const suite = await this.buildSuite();
       const result = await suite.run(this.logger);
 
-      if(parsedCommand.groupBy === "none") {
+      if (parsedCommand.groupBy === "none") {
         this.logResults(result, formatter);
       } else {
-        const groupedResult = parsedCommand.groupBy === "rule" ? result.getResultsByRule() : result.getResultsByRegistry();
+        const groupedResult =
+          parsedCommand.groupBy === "rule" ? result.getResultsByRule() : result.getResultsByRegistry();
         this.logGroupedResults(groupedResult, formatter);
       }
 

--- a/packages/cli/src/parser.ts
+++ b/packages/cli/src/parser.ts
@@ -11,7 +11,11 @@ const subParser = parser.addSubparsers({
 subParser.addParser("init");
 
 const runParser = subParser.addParser("run");
-runParser.addArgument("--groupBy", { help: "Group results by rule name or registry name", choices: ["rule", "registry", "none"], defaultValue: "none" });
+runParser.addArgument("--groupBy", {
+  help: "Group results by rule name or registry name",
+  choices: ["rule", "registry", "none"],
+  defaultValue: "none"
+});
 
 export type ParsedCommand = {
   azure_devops: boolean;

--- a/packages/cli/src/parser.ts
+++ b/packages/cli/src/parser.ts
@@ -1,0 +1,20 @@
+import { ArgumentParser } from "argparse";
+
+export const parser = new ArgumentParser({ description: "@boll/cli" });
+parser.addArgument("--azure-devops", { help: "Enable Azure DevOps pipeline output formatter.", action: "storeTrue" });
+
+const subParser = parser.addSubparsers({
+  description: "commands",
+  dest: "command"
+});
+
+subParser.addParser("init");
+
+const runParser = subParser.addParser("run");
+runParser.addArgument("--groupBy", { help: "Group results by rule name or registry name", choices: ["rule", "registry", "none"], defaultValue: "none" });
+
+export type ParsedCommand = {
+  azure_devops: boolean;
+  command: "run" | "init";
+  groupBy: "rule" | "registry" | "none";
+};

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -44,7 +44,7 @@ export class Config {
 
         if (typeof fn === "function") {
           const rule = fn(this.logger, options);
-          return new InstantiatedPackageRule(rule.name, check.severity || "error", rule);
+          return new InstantiatedPackageRule(rule.name, check.severity || "error", rule, check.rule);
         }
 
         return new InstantiatedPackageRule(fn.name, check.severity || "error", fn, options);
@@ -57,10 +57,10 @@ export class Config {
 
         if (typeof fn === "function") {
           const rule = fn(this.logger, options);
-          return new InstantiatedPackageMetaRule(rule.name, check.severity || "error", rule);
+          return new InstantiatedPackageMetaRule(rule.name, check.severity || "error", rule, check.rule);
         }
 
-        return new InstantiatedPackageMetaRule(fn.name, check.severity || "error", fn, options);
+        return new InstantiatedPackageMetaRule(fn.name, check.severity || "error", fn, check.rule, options);
       });
 
       return new RuleSet(glob, fileChecks, metaChecks);

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -47,7 +47,7 @@ export class Config {
           return new InstantiatedPackageRule(rule.name, check.severity || "error", rule, check.rule);
         }
 
-        return new InstantiatedPackageRule(fn.name, check.severity || "error", fn, options);
+        return new InstantiatedPackageRule(fn.name, check.severity || "error", fn, check.rule, options);
       });
       const metaChecks = ((ruleSetConfig.checks && ruleSetConfig.checks.meta) || []).map(check => {
         const optionsFromConfig =

--- a/packages/core/src/result-set.ts
+++ b/packages/core/src/result-set.ts
@@ -65,17 +65,17 @@ export class ResultSet {
     return this.groupResults('ruleName');
   }
 
-  private groupResults(getBy: keyof RuleResult): GroupedResult {
+  private groupResults(groupBy: keyof RuleResult): GroupedResult {
     const groupedResult: GroupedResult = {};
     (<('errors' | 'warnings')[]>['errors', 'warnings']).forEach((resultType) => {
       this[resultType].forEach(result => {
-        if(!groupedResult[result[getBy]]) {
-          groupedResult[result[getBy]] = {
+        if(!groupedResult[result[groupBy]]) {
+          groupedResult[result[groupBy]] = {
             errors: [],
             warnings: []
           };
         }
-        groupedResult[result[getBy]][resultType].push(result);
+        groupedResult[result[groupBy]][resultType].push(result);
       });
     })
 

--- a/packages/core/src/result-set.ts
+++ b/packages/core/src/result-set.ts
@@ -8,7 +8,7 @@ export interface Result {
   status: ResultStatus;
 }
 
-export interface RuleResult extends Result{
+export interface RuleResult extends Result {
   registryName: string;
   ruleName: string;
 }
@@ -17,7 +17,7 @@ export interface GroupedResult {
   [group: string]: {
     errors: RuleResult[];
     warnings: RuleResult[];
-  }
+  };
 }
 
 export class Success implements Result {
@@ -47,7 +47,6 @@ export class Failure implements Result {
 export class ResultSet {
   errors: RuleResult[] = [];
   warnings: RuleResult[] = [];
-  
 
   get hasErrors(): boolean {
     return this.errors.length > 0;
@@ -58,18 +57,18 @@ export class ResultSet {
   }
 
   getResultsByRegistry(): { [registerName: string]: { errors: RuleResult[]; warnings: RuleResult[] } } {
-    return this.groupResults('registryName');
+    return this.groupResults("registryName");
   }
 
   getResultsByRule(): { [ruleName: string]: { errors: RuleResult[]; warnings: RuleResult[] } } {
-    return this.groupResults('ruleName');
+    return this.groupResults("ruleName");
   }
 
   private groupResults(groupBy: keyof RuleResult): GroupedResult {
     const groupedResult: GroupedResult = {};
-    (<('errors' | 'warnings')[]>['errors', 'warnings']).forEach((resultType) => {
+    (<("errors" | "warnings")[]>["errors", "warnings"]).forEach(resultType => {
       this[resultType].forEach(result => {
-        if(!groupedResult[result[groupBy]]) {
+        if (!groupedResult[result[groupBy]]) {
           groupedResult[result[groupBy]] = {
             errors: [],
             warnings: []
@@ -77,13 +76,13 @@ export class ResultSet {
         }
         groupedResult[result[groupBy]][resultType].push(result);
       });
-    })
+    });
 
     return groupedResult;
-}
+  }
 
   addErrors(results: Result[], rule: InstantiatedRule) {
-    results.forEach((result) => {
+    results.forEach(result => {
       (<RuleResult>result).registryName = rule.registryName;
       (<RuleResult>result).ruleName = rule.name;
 

--- a/packages/core/src/rule-set.ts
+++ b/packages/core/src/rule-set.ts
@@ -15,7 +15,13 @@ export interface RuleOptions {
 }
 
 export class BasePackageRule<T> {
-  constructor(public name: string, public severity: CheckSeverity, public rule: T, public registryName: string, public options?: RuleOptions) {}
+  constructor(
+    public name: string,
+    public severity: CheckSeverity,
+    public rule: T,
+    public registryName: string,
+    public options?: RuleOptions
+  ) {}
 }
 
 export class InstantiatedPackageRule extends BasePackageRule<PackageRule> implements InstantiatedRule {

--- a/packages/core/src/rule-set.ts
+++ b/packages/core/src/rule-set.ts
@@ -4,6 +4,7 @@ import { CheckSeverity, FileGlob, PackageMetaRule, PackageRule } from "./types";
 import { Logger } from "./logger";
 
 export interface InstantiatedRule {
+  registryName: string;
   name: string;
   severity: CheckSeverity;
 }
@@ -14,7 +15,7 @@ export interface RuleOptions {
 }
 
 export class BasePackageRule<T> {
-  constructor(public name: string, public severity: CheckSeverity, public rule: T, public options?: RuleOptions) {}
+  constructor(public name: string, public severity: CheckSeverity, public rule: T, public registryName: string, public options?: RuleOptions) {}
 }
 
 export class InstantiatedPackageRule extends BasePackageRule<PackageRule> implements InstantiatedRule {

--- a/packages/core/src/suite.ts
+++ b/packages/core/src/suite.ts
@@ -94,9 +94,9 @@ export class Suite {
 
   private addFailuresWithSeverity(rule: InstantiatedRule, results: Result[], resultSet: ResultSet) {
     if (rule.severity === "error") {
-      resultSet.addErrors(results);
+      resultSet.addErrors(results, rule);
     } else if (rule.severity === "warn") {
-      resultSet.addWarnings(results);
+      resultSet.addWarnings(results, rule);
     } else {
       throw new Error("Unknown severity! (This is likely a boll bug)");
     }

--- a/packages/core/src/tests/result.test.ts
+++ b/packages/core/src/tests/result.test.ts
@@ -89,7 +89,7 @@ test("should log a failure as a warning if configured in the rule", async () => 
   });
 });
 
-test("should group results by rule name", async() => {
+test("should group results by rule name", async () => {
   await inFixtureDir("project-a", __dirname, async () => {
     const ruleRegistry = new RuleRegistry();
     ruleRegistry.register("foo", (l: any, options: any) => {
@@ -98,16 +98,17 @@ test("should group results by rule name", async() => {
     ruleRegistry.register("bar", (l: any, options: any) => {
       return new FakeRule2(options);
     });
-    
+
     const config = new Config(new ConfigRegistry(), ruleRegistry, NullLogger);
     const myConfig = {
       ruleSets: [
         {
           fileLocator: new TypescriptSourceGlob(),
-          checks: { 
-            file: [{ severity: "warn", rule: "foo", options: { bar: "baz" } } as CheckConfiguration,
-            { severity: "error", rule: "bar", options: { bar: "baz" } } as CheckConfiguration
-          ]
+          checks: {
+            file: [
+              { severity: "warn", rule: "foo", options: { bar: "baz" } } as CheckConfiguration,
+              { severity: "error", rule: "bar", options: { bar: "baz" } } as CheckConfiguration
+            ]
           }
         }
       ],
@@ -121,16 +122,16 @@ test("should group results by rule name", async() => {
     const suite = await config.buildSuite();
     const results = await suite.run(NullLogger);
     const groupedByRuleNameResults = results.getResultsByRule();
-    assert.ok(groupedByRuleNameResults["fakerule"])
-    assert.ok(groupedByRuleNameResults["fakerule2"])
+    assert.ok(groupedByRuleNameResults["fakerule"]);
+    assert.ok(groupedByRuleNameResults["fakerule2"]);
     assert.strictEqual(groupedByRuleNameResults["fakerule"].errors.length, 0);
     assert.strictEqual(groupedByRuleNameResults["fakerule"].warnings.length, 2);
     assert.strictEqual(groupedByRuleNameResults["fakerule2"].errors.length, 2);
     assert.strictEqual(groupedByRuleNameResults["fakerule2"].warnings.length, 0);
   });
-})
+});
 
-test("should group results by rule name and accumulate results", async() => {
+test("should group results by rule name and accumulate results", async () => {
   await inFixtureDir("project-a", __dirname, async () => {
     const ruleRegistry = new RuleRegistry();
     ruleRegistry.register("foo", (l: any, options: any) => {
@@ -144,10 +145,12 @@ test("should group results by rule name and accumulate results", async() => {
       ruleSets: [
         {
           fileLocator: new TypescriptSourceGlob(),
-          checks: { file: [
-            { severity: "warn", rule: "foo", options: { bar: "baz" } } as CheckConfiguration, 
-            { severity: "warn", rule: "bar", options: { bar: "baz" } } as CheckConfiguration
-          ] }
+          checks: {
+            file: [
+              { severity: "warn", rule: "foo", options: { bar: "baz" } } as CheckConfiguration,
+              { severity: "warn", rule: "bar", options: { bar: "baz" } } as CheckConfiguration
+            ]
+          }
         }
       ],
       configuration: {
@@ -163,9 +166,9 @@ test("should group results by rule name and accumulate results", async() => {
     assert.strictEqual(groupedByRuleNameResults["fakerule"].errors.length, 0);
     assert.strictEqual(groupedByRuleNameResults["fakerule"].warnings.length, 4);
   });
-})
+});
 
-test("should group results by registry", async() => {
+test("should group results by registry", async () => {
   await inFixtureDir("project-a", __dirname, async () => {
     const ruleRegistry = new RuleRegistry();
     ruleRegistry.register("foo", (l: any, options: any) => {
@@ -174,14 +177,18 @@ test("should group results by registry", async() => {
     ruleRegistry.register("fooz", (l: any, options: any) => {
       return new FakeRule2(options);
     });
-    
+
     const config = new Config(new ConfigRegistry(), ruleRegistry, NullLogger);
     const myConfig = {
       ruleSets: [
         {
           fileLocator: new TypescriptSourceGlob(),
-          checks: { file: [{ severity: "error", rule: "foo", options: { bar: "baz" } } as CheckConfiguration,
-          { severity: "warn", rule: "fooz", options: { bar: "baz" } } as CheckConfiguration] }
+          checks: {
+            file: [
+              { severity: "error", rule: "foo", options: { bar: "baz" } } as CheckConfiguration,
+              { severity: "warn", rule: "fooz", options: { bar: "baz" } } as CheckConfiguration
+            ]
+          }
         }
       ],
       configuration: {
@@ -194,11 +201,11 @@ test("should group results by registry", async() => {
     const suite = await config.buildSuite();
     const results = await suite.run(NullLogger);
     const groupedByRuleNameRegistry = results.getResultsByRegistry();
-    assert.ok(groupedByRuleNameRegistry["foo"])
-    assert.ok(groupedByRuleNameRegistry["fooz"])
+    assert.ok(groupedByRuleNameRegistry["foo"]);
+    assert.ok(groupedByRuleNameRegistry["fooz"]);
     assert.strictEqual(groupedByRuleNameRegistry["foo"].errors.length, 2);
     assert.strictEqual(groupedByRuleNameRegistry["foo"].warnings.length, 0);
     assert.strictEqual(groupedByRuleNameRegistry["fooz"].errors.length, 0);
     assert.strictEqual(groupedByRuleNameRegistry["fooz"].warnings.length, 2);
   });
-})
+});

--- a/packages/core/src/tests/result.test.ts
+++ b/packages/core/src/tests/result.test.ts
@@ -26,6 +26,16 @@ class FakeRule implements PackageRule {
   }
 }
 
+class FakeRule2 implements PackageRule {
+  name: string = "fakerule2";
+
+  constructor(public options: {} = {}) {}
+
+  async check(file: FileContext): Promise<Result[]> {
+    return [new Failure(this.name, file.filename, asBollLineNumber(0), "Something went wrong.")];
+  }
+}
+
 test("should log a failure as an error by default", async () => {
   await inFixtureDir("project-a", __dirname, async () => {
     const ruleRegistry = new RuleRegistry();
@@ -78,3 +88,117 @@ test("should log a failure as a warning if configured in the rule", async () => 
     assert.strictEqual(results.warnings.length, 2);
   });
 });
+
+test("should group results by rule name", async() => {
+  await inFixtureDir("project-a", __dirname, async () => {
+    const ruleRegistry = new RuleRegistry();
+    ruleRegistry.register("foo", (l: any, options: any) => {
+      return new FakeRule(options);
+    });
+    ruleRegistry.register("bar", (l: any, options: any) => {
+      return new FakeRule2(options);
+    });
+    
+    const config = new Config(new ConfigRegistry(), ruleRegistry, NullLogger);
+    const myConfig = {
+      ruleSets: [
+        {
+          fileLocator: new TypescriptSourceGlob(),
+          checks: { 
+            file: [{ severity: "warn", rule: "foo", options: { bar: "baz" } } as CheckConfiguration,
+            { severity: "error", rule: "bar", options: { bar: "baz" } } as CheckConfiguration
+          ]
+          }
+        }
+      ],
+      configuration: {
+        rules: {
+          foo: { some: "rule" }
+        }
+      }
+    };
+    config.load(myConfig);
+    const suite = await config.buildSuite();
+    const results = await suite.run(NullLogger);
+    const groupedByRuleNameResults = results.getResultsByRule();
+    assert.ok(groupedByRuleNameResults["fakerule"])
+    assert.ok(groupedByRuleNameResults["fakerule2"])
+    assert.strictEqual(groupedByRuleNameResults["fakerule"].errors.length, 0);
+    assert.strictEqual(groupedByRuleNameResults["fakerule"].warnings.length, 2);
+    assert.strictEqual(groupedByRuleNameResults["fakerule2"].errors.length, 2);
+    assert.strictEqual(groupedByRuleNameResults["fakerule2"].warnings.length, 0);
+  });
+})
+
+test("should group results by rule name and accumulate results", async() => {
+  await inFixtureDir("project-a", __dirname, async () => {
+    const ruleRegistry = new RuleRegistry();
+    ruleRegistry.register("foo", (l: any, options: any) => {
+      return new FakeRule(options);
+    });
+    ruleRegistry.register("bar", (l: any, options: any) => {
+      return new FakeRule(options);
+    });
+    const config = new Config(new ConfigRegistry(), ruleRegistry, NullLogger);
+    const myConfig = {
+      ruleSets: [
+        {
+          fileLocator: new TypescriptSourceGlob(),
+          checks: { file: [
+            { severity: "warn", rule: "foo", options: { bar: "baz" } } as CheckConfiguration, 
+            { severity: "warn", rule: "bar", options: { bar: "baz" } } as CheckConfiguration
+          ] }
+        }
+      ],
+      configuration: {
+        rules: {
+          foo: { some: "rule" }
+        }
+      }
+    };
+    config.load(myConfig);
+    const suite = await config.buildSuite();
+    const results = await suite.run(NullLogger);
+    const groupedByRuleNameResults = results.getResultsByRule();
+    assert.strictEqual(groupedByRuleNameResults["fakerule"].errors.length, 0);
+    assert.strictEqual(groupedByRuleNameResults["fakerule"].warnings.length, 4);
+  });
+})
+
+test("should group results by registry", async() => {
+  await inFixtureDir("project-a", __dirname, async () => {
+    const ruleRegistry = new RuleRegistry();
+    ruleRegistry.register("foo", (l: any, options: any) => {
+      return new FakeRule(options);
+    });
+    ruleRegistry.register("fooz", (l: any, options: any) => {
+      return new FakeRule2(options);
+    });
+    
+    const config = new Config(new ConfigRegistry(), ruleRegistry, NullLogger);
+    const myConfig = {
+      ruleSets: [
+        {
+          fileLocator: new TypescriptSourceGlob(),
+          checks: { file: [{ severity: "error", rule: "foo", options: { bar: "baz" } } as CheckConfiguration,
+          { severity: "warn", rule: "fooz", options: { bar: "baz" } } as CheckConfiguration] }
+        }
+      ],
+      configuration: {
+        rules: {
+          foo: { some: "rule" }
+        }
+      }
+    };
+    config.load(myConfig);
+    const suite = await config.buildSuite();
+    const results = await suite.run(NullLogger);
+    const groupedByRuleNameRegistry = results.getResultsByRegistry();
+    assert.ok(groupedByRuleNameRegistry["foo"])
+    assert.ok(groupedByRuleNameRegistry["fooz"])
+    assert.strictEqual(groupedByRuleNameRegistry["foo"].errors.length, 2);
+    assert.strictEqual(groupedByRuleNameRegistry["foo"].warnings.length, 0);
+    assert.strictEqual(groupedByRuleNameRegistry["fooz"].errors.length, 0);
+    assert.strictEqual(groupedByRuleNameRegistry["fooz"].warnings.length, 2);
+  });
+})

--- a/packages/recommended/src/index.ts
+++ b/packages/recommended/src/index.ts
@@ -31,7 +31,7 @@ export const bootstrapRecommendedConfiguration = () => {
   RuleRegistryInstance.register("NodeModulesReferenceDetector", () => new NodeModulesReferenceDetector());
   RuleRegistryInstance.register("RedundantImportsDetectors", () => new RedundantImportsDetector());
   RuleRegistryInstance.register("SrcDetector", () => new SrcDetector());
-  RuleRegistryInstance.register("TransitiveDependencyDetectors", () => new TransitiveDependencyDetector());
+  RuleRegistryInstance.register("TransitiveDependencyDetector", () => new TransitiveDependencyDetector());
 
   // External tools rules
   RuleRegistryInstance.register("ESLintPreferConstRule", (l: Logger) => new ESLintPreferConstRule(l));
@@ -56,7 +56,7 @@ export const RecommendedConfig: ConfigDefinition = {
         file: [
           { rule: "SrcDetector" },
           { rule: "CrossPackageDependencyDetector" },
-          { rule: "TransitiveDependencyDetectors" },
+          { rule: "TransitiveDependencyDetector" },
           { rule: "NodeModulesReferenceDetector" },
           { rule: "RedundantImportsDetectors" }
         ]

--- a/packages/recommended/src/index.ts
+++ b/packages/recommended/src/index.ts
@@ -29,7 +29,7 @@ export const bootstrapRecommendedConfiguration = () => {
   // TypeScript rules
   RuleRegistryInstance.register("CrossPackageDependencyDetector", () => new CrossPackageDependencyDetector());
   RuleRegistryInstance.register("NodeModulesReferenceDetector", () => new NodeModulesReferenceDetector());
-  RuleRegistryInstance.register("RedundantImportsDetectors", () => new RedundantImportsDetector());
+  RuleRegistryInstance.register("RedundantImportsDetector", () => new RedundantImportsDetector());
   RuleRegistryInstance.register("SrcDetector", () => new SrcDetector());
   RuleRegistryInstance.register("TransitiveDependencyDetector", () => new TransitiveDependencyDetector());
 
@@ -58,7 +58,7 @@ export const RecommendedConfig: ConfigDefinition = {
           { rule: "CrossPackageDependencyDetector" },
           { rule: "TransitiveDependencyDetector" },
           { rule: "NodeModulesReferenceDetector" },
-          { rule: "RedundantImportsDetectors" }
+          { rule: "RedundantImportsDetector" }
         ]
       }
     },

--- a/packages/recommended/src/index.ts
+++ b/packages/recommended/src/index.ts
@@ -29,9 +29,9 @@ export const bootstrapRecommendedConfiguration = () => {
   // TypeScript rules
   RuleRegistryInstance.register("CrossPackageDependencyDetector", () => new CrossPackageDependencyDetector());
   RuleRegistryInstance.register("NodeModulesReferenceDetector", () => new NodeModulesReferenceDetector());
-  RuleRegistryInstance.register("RedundantImportsDetector", () => new RedundantImportsDetector());
+  RuleRegistryInstance.register("RedundantImportsDetectors", () => new RedundantImportsDetector());
   RuleRegistryInstance.register("SrcDetector", () => new SrcDetector());
-  RuleRegistryInstance.register("TransitiveDependencyDetector", () => new TransitiveDependencyDetector());
+  RuleRegistryInstance.register("TransitiveDependencyDetectors", () => new TransitiveDependencyDetector());
 
   // External tools rules
   RuleRegistryInstance.register("ESLintPreferConstRule", (l: Logger) => new ESLintPreferConstRule(l));
@@ -56,9 +56,9 @@ export const RecommendedConfig: ConfigDefinition = {
         file: [
           { rule: "SrcDetector" },
           { rule: "CrossPackageDependencyDetector" },
-          { rule: "TransitiveDependencyDetector" },
+          { rule: "TransitiveDependencyDetectors" },
           { rule: "NodeModulesReferenceDetector" },
-          { rule: "RedundantImportsDetector" }
+          { rule: "RedundantImportsDetectors" }
         ]
       }
     },


### PR DESCRIPTION
Add argument `--groupBy` to group results by registry name, rule name or have legacy results.

e.g. using cli `boll run --groupBy=<rule|registry|none>`

or using api
```javascript
const results = await suite.run(this.logger);
const groupedResults = results.getResultsByRule() // or results.getResultsByRegistry()
```

### None
Default choice. Presents results as boll did before
```
{
  "errors": ["foo error", "bar error"],
  "warnings": ["foo warning", "bar warning"]
}
```

### Rule
Groups by rule names
e.g. 
for rules `{name: 'foo', check: fn}` and  `{name: 'bar', check: fn}`
the result is
```
{
  "foo": {
    "errors": ["foo error", "foo error2"],
    "warnings": ["foo warning"]
  },
  "bar": {
    "errors": ["bar error", "bar error2"],
    "warnings": ["bar warning"]
  }
}
```

### Registry
Groups by rule registry name
e.g. 
for config
```javascript
RuleRegistryInstance.register("foo", () => new fooz());
RuleRegistryInstance.register("bar", () => new baz());

 {
  name: "myconfig",
  ruleSets: [
    {
      fileLocator: new TypescriptSourceGlob(),
      checks: {
        file: [
          { rule: "foo" },
          { rule: "bar" },
        ]
      }
    },
  ]
};
```
the result is
```
{
  "foo": {
    "errors": ["fooz error", "fooz error2"],
    "warnings": ["fooz warning"]
  },
  "bar": {
    "errors": ["baz error", "baz error2"],
    "warnings": ["baz warning"]
  }
}
```

