### PR TITLE
Fix release workflow and sync with published versions

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       - run: yarn

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
           persist-credentials: false
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
 
@@ -49,4 +49,5 @@ jobs:
 
           yarn release -y -n "$NPM_AUTHTOKEN"
         env:
-          NPM_AUTHTOKEN: ${{ secrets.npm_authtoken }}
+          NPM_AUTHTOKEN: ${{ secrets.NPM_AUTHTOKEN }}
+          REPO_PAT: ${{ secrets.REPO_PAT }}

--- a/beachball.config.js
+++ b/beachball.config.js
@@ -1,0 +1,14 @@
+// @ts-check
+/** @type {import("beachball").BeachballConfig} */
+const config = {
+  changehint: 'Run "yarn change" to generate a change file',
+  branch: "main",
+  groupChanges: true,
+  ignorePatterns: ["**/fixtures/**", "**/tests/**"],
+  disallowedChangeTypes: [
+    "prerelease",
+    // If a major release is needed, temporarily remove this line.
+    "major"
+  ]
+};
+module.exports = config;

--- a/change/@boll-cli-2023-07-06-12-35-26-customize-results.json
+++ b/change/@boll-cli-2023-07-06-12-35-26-customize-results.json
@@ -1,8 +1,0 @@
-{
-  "type": "minor",
-  "comment": "Add grouping option",
-  "packageName": "@boll/cli",
-  "email": "bmuthengi@microsoft.com",
-  "dependentChangeType": "patch",
-  "date": "2023-07-06T09:35:01.159Z"
-}

--- a/change/@boll-core-2023-07-06-12-35-26-customize-results.json
+++ b/change/@boll-core-2023-07-06-12-35-26-customize-results.json
@@ -1,8 +1,0 @@
-{
-  "type": "minor",
-  "comment": "Group results (#119)",
-  "packageName": "@boll/core",
-  "email": "bmuthengi@microsoft.com",
-  "dependentChangeType": "patch",
-  "date": "2023-07-06T09:35:26.359Z"
-}

--- a/change/change-e6ed2180-cf8d-4367-b32f-493527e8cc30.json
+++ b/change/change-e6ed2180-cf8d-4367-b32f-493527e8cc30.json
@@ -1,0 +1,53 @@
+{
+  "changes": [
+    {
+      "type": "none",
+      "comment": "Syncing after failed post-publish push",
+      "packageName": "@boll/cli",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "none"
+    },
+    {
+      "type": "none",
+      "comment": "Syncing after failed post-publish push",
+      "packageName": "@boll/core",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "none"
+    },
+    {
+      "type": "none",
+      "comment": "Syncing after failed post-publish push",
+      "packageName": "@boll/recommended",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "none"
+    },
+    {
+      "type": "none",
+      "comment": "Syncing after failed post-publish push",
+      "packageName": "@boll/rules-core",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "none"
+    },
+    {
+      "type": "none",
+      "comment": "Syncing after failed post-publish push",
+      "packageName": "@boll/rules-external-tools",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "none"
+    },
+    {
+      "type": "none",
+      "comment": "Syncing after failed post-publish push",
+      "packageName": "@boll/rules-monorepo",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "none"
+    },
+    {
+      "type": "none",
+      "comment": "Syncing after failed post-publish push",
+      "packageName": "@boll/rules-typescript",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "none"
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -7,10 +7,9 @@
     "prettier": "^2.8.1"
   },
   "license": "MIT",
-  "main": "index.js",
-  "name": "boll",
+  "name": "@boll/boll-repo",
   "private": true,
-  "repository": "https://github.com/jdhuntington/boll.git",
+  "repository": "https://github.com/microsoft/boll.git",
   "scripts": {
     "build": "lage build",
     "change": "beachball change -b origin/main",

--- a/packages/cli/CHANGELOG.json
+++ b/packages/cli/CHANGELOG.json
@@ -2,6 +2,28 @@
   "name": "@boll/cli",
   "entries": [
     {
+      "date": "Mon, 17 Jul 2023 21:31:15 GMT",
+      "tag": "@boll/cli_v2.2.0",
+      "version": "2.2.0",
+      "comments": {
+        "minor": [
+          {
+            "author": "bmuthengi@microsoft.com",
+            "package": "@boll/cli",
+            "commit": "d31d2ce0a5022db88e364ce3afee5c934c75a99d",
+            "comment": "Add grouping option",
+            "date": "2023-07-06T09:35:01.159Z"
+          },
+          {
+            "author": "beachball",
+            "package": "@boll/cli",
+            "comment": "Bump @boll/core to v3.2.0",
+            "commit": "586cac01d0111efdb7dc57319f3308eed173dc35"
+          }
+        ]
+      }
+    },
+    {
       "date": "Wed, 25 Jan 2023 20:39:53 GMT",
       "tag": "@boll/cli_v2.0.0",
       "version": "2.0.0",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,8 +1,17 @@
 # Change Log - @boll/cli
 
-This log was last generated on Wed, 25 Jan 2023 20:39:53 GMT and should not be manually modified.
+This log was last generated on Mon, 17 Jul 2023 21:31:15 GMT and should not be manually modified.
 
 <!-- Start content -->
+
+## 2.2.0
+
+Mon, 17 Jul 2023 21:31:15 GMT
+
+### Minor changes
+
+- Add grouping option (bmuthengi@microsoft.com)
+- Bump @boll/core to v3.2.0
 
 ## 2.0.0
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/microsoft/boll/issues"
   },
   "dependencies": {
-    "@boll/core": "3.1.0",
+    "@boll/core": "3.2.0",
     "argparse": "^1.0.10",
     "fast-glob": "^3.2.4",
     "typescript": "^4.9.4",
@@ -48,5 +48,5 @@
     "docs": "typedoc --mode file --out ./apidocs --theme markdown ./src",
     "test": "node dist/tests/all.test.js"
   },
-  "version": "2.1.0"
+  "version": "2.2.0"
 }

--- a/packages/core/CHANGELOG.json
+++ b/packages/core/CHANGELOG.json
@@ -2,6 +2,22 @@
   "name": "@boll/core",
   "entries": [
     {
+      "date": "Mon, 17 Jul 2023 21:31:15 GMT",
+      "tag": "@boll/core_v3.2.0",
+      "version": "3.2.0",
+      "comments": {
+        "minor": [
+          {
+            "author": "bmuthengi@microsoft.com",
+            "package": "@boll/core",
+            "commit": "d31d2ce0a5022db88e364ce3afee5c934c75a99d",
+            "comment": "Group results (#119)",
+            "date": "2023-07-06T09:35:26.359Z"
+          }
+        ]
+      }
+    },
+    {
       "date": "Wed, 25 Jan 2023 20:39:53 GMT",
       "tag": "@boll/core_v3.0.0",
       "version": "3.0.0",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,8 +1,16 @@
 # Change Log - @boll/core
 
-This log was last generated on Wed, 25 Jan 2023 20:39:53 GMT and should not be manually modified.
+This log was last generated on Mon, 17 Jul 2023 21:31:15 GMT and should not be manually modified.
 
 <!-- Start content -->
+
+## 3.2.0
+
+Mon, 17 Jul 2023 21:31:15 GMT
+
+### Minor changes
+
+- Group results (#119) (bmuthengi@microsoft.com)
 
 ## 3.0.0
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -46,5 +46,5 @@
     "docs": "typedoc --mode file --out ./apidocs --theme markdown ./src",
     "test": "node dist/tests/all.test.js"
   },
-  "version": "3.1.0"
+  "version": "3.2.0"
 }

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -5,11 +5,11 @@
   },
   "description": "> TODO: description",
   "devDependencies": {
-    "@boll/cli": "2.1.0",
-    "@boll/core": "3.1.0",
-    "@boll/rules-core": "1.0.1",
-    "@boll/rules-external-tools": "1.0.1",
-    "@boll/rules-typescript": "2.0.1",
+    "@boll/cli": "2.2.0",
+    "@boll/core": "3.2.0",
+    "@boll/rules-core": "1.0.2",
+    "@boll/rules-external-tools": "1.0.2",
+    "@boll/rules-typescript": "2.0.2",
     "gh-pages": "^3.1.0",
     "fast-glob": "^3.2.4",
     "vuepress": "1.5.4"

--- a/packages/integration/package.json
+++ b/packages/integration/package.json
@@ -4,10 +4,10 @@
     "url": "https://github.com/microsoft/boll/issues"
   },
   "dependencies": {
-    "@boll/cli": "2.1.0",
-    "@boll/core": "3.1.0",
-    "@boll/recommended": "2.0.1",
-    "@boll/rules-typescript": "2.0.1"
+    "@boll/cli": "2.2.0",
+    "@boll/core": "3.2.0",
+    "@boll/recommended": "2.0.2",
+    "@boll/rules-typescript": "2.0.2"
   },
   "devDependencies": {
     "@boll/test-internal": "0.0.1",

--- a/packages/recommended/CHANGELOG.json
+++ b/packages/recommended/CHANGELOG.json
@@ -2,6 +2,45 @@
   "name": "@boll/recommended",
   "entries": [
     {
+      "date": "Mon, 17 Jul 2023 21:31:15 GMT",
+      "tag": "@boll/recommended_v2.0.2",
+      "version": "2.0.2",
+      "comments": {
+        "patch": [
+          {
+            "author": "beachball",
+            "package": "@boll/recommended",
+            "comment": "Bump @boll/core to v3.2.0",
+            "commit": "586cac01d0111efdb7dc57319f3308eed173dc35"
+          },
+          {
+            "author": "beachball",
+            "package": "@boll/recommended",
+            "comment": "Bump @boll/rules-external-tools to v1.0.2",
+            "commit": "586cac01d0111efdb7dc57319f3308eed173dc35"
+          },
+          {
+            "author": "beachball",
+            "package": "@boll/recommended",
+            "comment": "Bump @boll/rules-core to v1.0.2",
+            "commit": "586cac01d0111efdb7dc57319f3308eed173dc35"
+          },
+          {
+            "author": "beachball",
+            "package": "@boll/recommended",
+            "comment": "Bump @boll/rules-monorepo to v1.0.2",
+            "commit": "586cac01d0111efdb7dc57319f3308eed173dc35"
+          },
+          {
+            "author": "beachball",
+            "package": "@boll/recommended",
+            "comment": "Bump @boll/rules-typescript to v2.0.2",
+            "commit": "586cac01d0111efdb7dc57319f3308eed173dc35"
+          }
+        ]
+      }
+    },
+    {
       "date": "Wed, 25 Jan 2023 20:39:53 GMT",
       "tag": "@boll/recommended_v2.0.0",
       "version": "2.0.0",

--- a/packages/recommended/CHANGELOG.md
+++ b/packages/recommended/CHANGELOG.md
@@ -1,8 +1,20 @@
 # Change Log - @boll/recommended
 
-This log was last generated on Wed, 25 Jan 2023 20:39:53 GMT and should not be manually modified.
+This log was last generated on Mon, 17 Jul 2023 21:31:15 GMT and should not be manually modified.
 
 <!-- Start content -->
+
+## 2.0.2
+
+Mon, 17 Jul 2023 21:31:15 GMT
+
+### Patches
+
+- Bump @boll/core to v3.2.0
+- Bump @boll/rules-external-tools to v1.0.2
+- Bump @boll/rules-core to v1.0.2
+- Bump @boll/rules-monorepo to v1.0.2
+- Bump @boll/rules-typescript to v2.0.2
 
 ## 2.0.0
 

--- a/packages/recommended/package.json
+++ b/packages/recommended/package.json
@@ -4,11 +4,11 @@
     "url": "https://github.com/microsoft/boll/issues"
   },
   "dependencies": {
-    "@boll/core": "3.1.0",
-    "@boll/rules-external-tools": "1.0.1",
-    "@boll/rules-core": "1.0.1",
-    "@boll/rules-monorepo": "1.0.1",
-    "@boll/rules-typescript": "2.0.1"
+    "@boll/core": "3.2.0",
+    "@boll/rules-external-tools": "1.0.2",
+    "@boll/rules-core": "1.0.2",
+    "@boll/rules-monorepo": "1.0.2",
+    "@boll/rules-typescript": "2.0.2"
   },
   "description": "Recommended configuration for TypeScript monorepos ",
   "devDependencies": {
@@ -38,5 +38,5 @@
     "clean": "rimraf ./dist",
     "docs": "typedoc --mode file --out ./apidocs --theme markdown ./src"
   },
-  "version": "2.0.1"
+  "version": "2.0.2"
 }

--- a/packages/rules-core/CHANGELOG.json
+++ b/packages/rules-core/CHANGELOG.json
@@ -2,6 +2,21 @@
   "name": "@boll/rules-core",
   "entries": [
     {
+      "date": "Mon, 17 Jul 2023 21:31:15 GMT",
+      "tag": "@boll/rules-core_v1.0.2",
+      "version": "1.0.2",
+      "comments": {
+        "patch": [
+          {
+            "author": "beachball",
+            "package": "@boll/rules-core",
+            "comment": "Bump @boll/core to v3.2.0",
+            "commit": "586cac01d0111efdb7dc57319f3308eed173dc35"
+          }
+        ]
+      }
+    },
+    {
       "date": "Wed, 25 Jan 2023 20:39:53 GMT",
       "tag": "@boll/rules-core_v1.0.0",
       "version": "1.0.0",

--- a/packages/rules-core/CHANGELOG.md
+++ b/packages/rules-core/CHANGELOG.md
@@ -1,8 +1,16 @@
 # Change Log - @boll/rules-core
 
-This log was last generated on Wed, 25 Jan 2023 20:39:53 GMT and should not be manually modified.
+This log was last generated on Mon, 17 Jul 2023 21:31:15 GMT and should not be manually modified.
 
 <!-- Start content -->
+
+## 1.0.2
+
+Mon, 17 Jul 2023 21:31:15 GMT
+
+### Patches
+
+- Bump @boll/core to v3.2.0
 
 ## 1.0.0
 

--- a/packages/rules-core/package.json
+++ b/packages/rules-core/package.json
@@ -4,7 +4,7 @@
     "url": "https://github.com/microsoft/boll/issues"
   },
   "dependencies": {
-    "@boll/core": "3.1.0"
+    "@boll/core": "3.2.0"
   },
   "description": "@boll rules for project configuration and layout",
   "devDependencies": {
@@ -39,5 +39,5 @@
     "docs": "typedoc --mode file --out ./apidocs --theme markdown ./src",
     "test": "node dist/tests/all.test.js"
   },
-  "version": "1.0.1"
+  "version": "1.0.2"
 }

--- a/packages/rules-external-tools/CHANGELOG.json
+++ b/packages/rules-external-tools/CHANGELOG.json
@@ -2,6 +2,21 @@
   "name": "@boll/rules-external-tools",
   "entries": [
     {
+      "date": "Mon, 17 Jul 2023 21:31:15 GMT",
+      "tag": "@boll/rules-external-tools_v1.0.2",
+      "version": "1.0.2",
+      "comments": {
+        "patch": [
+          {
+            "author": "beachball",
+            "package": "@boll/rules-external-tools",
+            "comment": "Bump @boll/core to v3.2.0",
+            "commit": "586cac01d0111efdb7dc57319f3308eed173dc35"
+          }
+        ]
+      }
+    },
+    {
       "date": "Wed, 25 Jan 2023 20:39:53 GMT",
       "tag": "@boll/rules-external-tools_v1.0.0",
       "version": "1.0.0",

--- a/packages/rules-external-tools/CHANGELOG.md
+++ b/packages/rules-external-tools/CHANGELOG.md
@@ -1,8 +1,16 @@
 # Change Log - @boll/rules-external-tools
 
-This log was last generated on Wed, 25 Jan 2023 20:39:53 GMT and should not be manually modified.
+This log was last generated on Mon, 17 Jul 2023 21:31:15 GMT and should not be manually modified.
 
 <!-- Start content -->
+
+## 1.0.2
+
+Mon, 17 Jul 2023 21:31:15 GMT
+
+### Patches
+
+- Bump @boll/core to v3.2.0
 
 ## 1.0.0
 

--- a/packages/rules-external-tools/package.json
+++ b/packages/rules-external-tools/package.json
@@ -4,7 +4,7 @@
     "url": "https://github.com/microsoft/boll/issues"
   },
   "dependencies": {
-    "@boll/core": "3.1.0",
+    "@boll/core": "3.2.0",
     "eslint": "^7.8.1"
   },
   "description": "@boll rules for typescript source files",
@@ -41,5 +41,5 @@
     "docs": "typedoc --mode file --out ./apidocs --theme markdown ./src",
     "test": "node dist/tests/all.test.js"
   },
-  "version": "1.0.1"
+  "version": "1.0.2"
 }

--- a/packages/rules-monorepo/CHANGELOG.json
+++ b/packages/rules-monorepo/CHANGELOG.json
@@ -2,6 +2,21 @@
   "name": "@boll/rules-monorepo",
   "entries": [
     {
+      "date": "Mon, 17 Jul 2023 21:31:15 GMT",
+      "tag": "@boll/rules-monorepo_v1.0.2",
+      "version": "1.0.2",
+      "comments": {
+        "patch": [
+          {
+            "author": "beachball",
+            "package": "@boll/rules-monorepo",
+            "comment": "Bump @boll/core to v3.2.0",
+            "commit": "586cac01d0111efdb7dc57319f3308eed173dc35"
+          }
+        ]
+      }
+    },
+    {
       "date": "Wed, 25 Jan 2023 20:39:53 GMT",
       "tag": "@boll/rules-monorepo_v1.0.0",
       "version": "1.0.0",

--- a/packages/rules-monorepo/CHANGELOG.md
+++ b/packages/rules-monorepo/CHANGELOG.md
@@ -1,8 +1,16 @@
 # Change Log - @boll/rules-monorepo
 
-This log was last generated on Wed, 25 Jan 2023 20:39:53 GMT and should not be manually modified.
+This log was last generated on Mon, 17 Jul 2023 21:31:15 GMT and should not be manually modified.
 
 <!-- Start content -->
+
+## 1.0.2
+
+Mon, 17 Jul 2023 21:31:15 GMT
+
+### Patches
+
+- Bump @boll/core to v3.2.0
 
 ## 1.0.0
 

--- a/packages/rules-monorepo/package.json
+++ b/packages/rules-monorepo/package.json
@@ -4,7 +4,7 @@
     "url": "https://github.com/microsoft/boll/issues"
   },
   "dependencies": {
-    "@boll/core": "3.1.0",
+    "@boll/core": "3.2.0",
     "typescript": "^4.9.4"
   },
   "description": "@boll rules for a large monorepo",
@@ -38,5 +38,5 @@
     "docs": "typedoc --mode file --out ./apidocs --theme markdown ./src",
     "test": ""
   },
-  "version": "1.0.1"
+  "version": "1.0.2"
 }

--- a/packages/rules-typescript/CHANGELOG.json
+++ b/packages/rules-typescript/CHANGELOG.json
@@ -2,6 +2,21 @@
   "name": "@boll/rules-typescript",
   "entries": [
     {
+      "date": "Mon, 17 Jul 2023 21:31:15 GMT",
+      "tag": "@boll/rules-typescript_v2.0.2",
+      "version": "2.0.2",
+      "comments": {
+        "patch": [
+          {
+            "author": "beachball",
+            "package": "@boll/rules-typescript",
+            "comment": "Bump @boll/core to v3.2.0",
+            "commit": "586cac01d0111efdb7dc57319f3308eed173dc35"
+          }
+        ]
+      }
+    },
+    {
       "date": "Wed, 25 Jan 2023 20:39:53 GMT",
       "tag": "@boll/rules-typescript_v2.0.0",
       "version": "2.0.0",

--- a/packages/rules-typescript/CHANGELOG.md
+++ b/packages/rules-typescript/CHANGELOG.md
@@ -1,8 +1,16 @@
 # Change Log - @boll/rules-typescript
 
-This log was last generated on Wed, 25 Jan 2023 20:39:53 GMT and should not be manually modified.
+This log was last generated on Mon, 17 Jul 2023 21:31:15 GMT and should not be manually modified.
 
 <!-- Start content -->
+
+## 2.0.2
+
+Mon, 17 Jul 2023 21:31:15 GMT
+
+### Patches
+
+- Bump @boll/core to v3.2.0
 
 ## 2.0.0
 

--- a/packages/rules-typescript/package.json
+++ b/packages/rules-typescript/package.json
@@ -4,7 +4,7 @@
     "url": "https://github.com/microsoft/boll/issues"
   },
   "dependencies": {
-    "@boll/core": "3.1.0",
+    "@boll/core": "3.2.0",
     "typescript": "^4.9.4"
   },
   "description": "@boll rules for typescript source files",
@@ -39,5 +39,5 @@
     "docs": "typedoc --mode file --out ./apidocs --theme markdown ./src",
     "test": "node dist/tests/all.test.js"
   },
-  "version": "2.0.1"
+  "version": "2.0.2"
 }


### PR DESCRIPTION
Pass the REPO_PAT secret into the beachball publish step in the release workflow (previously it was not set, so auth didn't work) and sync the versions and changelogs from the most recent publish where pushing failed.

Other minor changes:
- Add a beachball config file with some newer convenience settings
- Update the setup-node action in workflows
- Fix the repository field in package.json so beachball can auto-detect the default remote for comparison