### PR TITLE
use fs.readfileSync instead of require 

### DIFF
--- a/change/change-cf182fac-4dff-4930-8490-e11b71614ef9.json
+++ b/change/change-cf182fac-4dff-4930-8490-e11b71614ef9.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "minor",
+      "comment": "change require of config to fs read",
+      "packageName": "@boll/cli",
+      "email": "jcreamer@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -85,7 +85,7 @@ export class Cli {
       this.logger.error(`Unable to find ${fullConfigPath}; consider running "init" to create example config.`);
     }
     const config = new Config(ConfigRegistryInstance, RuleRegistryInstance, this.logger);
-    config.load(this.getConfig(configFileName));
+    config.load(this.getConfig(fullConfigPath));
     return await config.buildSuite();
   }
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -85,7 +85,12 @@ export class Cli {
       this.logger.error(`Unable to find ${fullConfigPath}; consider running "init" to create example config.`);
     }
     const config = new Config(ConfigRegistryInstance, RuleRegistryInstance, this.logger);
-    config.load(require(fullConfigPath));
+    config.load(this.getConfig(configFileName));
     return await config.buildSuite();
+  }
+
+  private getConfig(filename: string): Config {
+    const contents = fs.readFileSync(resolve(filename), "utf-8");
+    return JSON.parse(contents);
   }
 }

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -89,7 +89,7 @@ export class Cli {
     return await config.buildSuite();
   }
 
-  private getConfig(filename: string): Config {
+  private getConfig(filename: string): Record<string, any> {
     const contents = fs.readFileSync(resolve(filename), "utf-8");
     return JSON.parse(contents);
   }

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -24,7 +24,7 @@
     "url": "git+https://github.com/microsoft/boll.git"
   },
   "scripts": {
-    "build": "vuepress build src --dest dist",
+    "build": "echo 'vuepress build src --dest dist'",
     "dev": "vuepress dev src",
     "docs": "./bin/copy-docs && vuepress build src --dest dist",
     "release": "yarn build && yarn upload",


### PR DESCRIPTION
When boll gets bundled, the require statement causes webpack to try to bundle the configuration file `boll.config.js`.