### PR TITLE
Share config loading logic

### DIFF
--- a/change/change-fa687c93-091a-4ecc-ae46-238edd21dcaa.json
+++ b/change/change-fa687c93-091a-4ecc-ae46-238edd21dcaa.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "type": "patch",
+      "comment": "Use the same config loading logic when running boll via API and CLI",
+      "packageName": "@boll/cli",
+      "email": "elcraig@microsoft.com",
+      "dependentChangeType": "patch"
+    }
+  ]
+}

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -1,4 +1,5 @@
 import * as fs from "fs";
+import * as path from "path";
 import {
   Config,
   configFileName,
@@ -8,14 +9,10 @@ import {
   RuleRegistryInstance,
   Suite
 } from "@boll/core";
-import { promisify } from "util";
-import { resolve } from "path";
-const fileExistsAsync = promisify(fs.exists);
 
 export async function buildSuite(logger: Logger): Promise<Suite> {
-  const fullConfigPath = resolve(configFileName);
-  const exists = await fileExistsAsync(fullConfigPath);
-  if (!exists) {
+  const fullConfigPath = path.resolve(configFileName);
+  if (!fs.existsSync(fullConfigPath)) {
     logger.error(`Unable to find ${fullConfigPath}; consider running "init" to create example config.`);
   }
   const config = new Config(ConfigRegistryInstance, RuleRegistryInstance, logger);
@@ -25,7 +22,7 @@ export async function buildSuite(logger: Logger): Promise<Suite> {
 
 /**
  * Entry point for external libraries running boll.
- * @returns {boolean} true if success, false if any warnings or errors.
+ * @returns true if success, false if any warnings or errors.
  */
 export async function runBoll(logger: Logger = DefaultLogger): Promise<boolean> {
   const suite = await buildSuite(logger);


### PR DESCRIPTION
Previously the tests and the API were using separate duplicate logic to load the config file, which meant a bug wasn't caught by the tests. This PR updates it to share the logic.