### PR TITLE
Dedupe boll version in docs

### DIFF
--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -13,11 +13,11 @@
     "upload": "gh-pages --dist dist --dotfiles"
   },
   "devDependencies": {
-    "@boll/cli": "2.3.3",
-    "@boll/core": "3.2.1",
-    "@boll/rules-core": "1.0.3",
-    "@boll/rules-external-tools": "1.0.3",
-    "@boll/rules-typescript": "2.0.3",
+    "@boll/cli": "*",
+    "@boll/core": "*",
+    "@boll/rules-core": "*",
+    "@boll/rules-external-tools": "*",
+    "@boll/rules-typescript": "*",
     "fast-glob": "^3.2.4",
     "gh-pages": "^5.0.0",
     "vuepress": "1.5.4"


### PR DESCRIPTION
For some reason the docs package's boll dependency didn't get updated by beachball, causing a duplicate when yarn runs. Switch all the internal deps in that package to just use `*` instead since it's not published.